### PR TITLE
Naming consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then specify the vertices, which can be optionally extracted from an '.obj' file
 ```c
 ch_vertex* vertices = NULL;
 int nVertices;
-extractVerticesFromObjFile(OBJ_FILE_NAME, &vertices, &nVertices);
+extract_vertices_from_obj_file(OBJ_FILE_NAME, &vertices, &nVertices);
 /* Where 'vertices' is a vector of vertices [nVertices].x, .y, .z  */
 ```
 

--- a/convhull_3d.h
+++ b/convhull_3d.h
@@ -99,11 +99,11 @@ void convhull_3d_export_m(/* input arguments */
                           char* const m_filename);              /* m filename, WITHOUT extension */
     
 /* reads an 'obj' file and extracts only the vertices (for 3d convexhulls only) */
-void extractVerticesFromObjFile(/* input arguments */
-                                char* const obj_filename,       /* obj filename, WITHOUT extension */
-                                /* output arguments */
-                                ch_vertex** out_vertices,       /* & of empty ch_vertex*, output vertices; out_nVert x 1 */
-                                int* out_nVert);                /* & of int, number of vertices */
+void extract_vertices_from_obj_file(/* input arguments */
+                                    char* const obj_filename,       /* obj filename, WITHOUT extension */
+                                    /* output arguments */
+                                    ch_vertex** out_vertices,       /* & of empty ch_vertex*, output vertices; out_nVert x 1 */
+                                    int* out_nVert);                /* & of int, number of vertices */
 
 /**** NEW! ****/
 
@@ -1117,7 +1117,11 @@ void convhull_3d_export_m
     fclose(m_file);
 }
 
-void extractVerticesFromObjFile(char* const obj_filename, ch_vertex** out_vertices, int* out_nVert)
+void extract_vertices_from_obj_file
+(
+    char* const obj_filename,
+    ch_vertex** out_vertices,
+    int* out_nVert)
 {
     FILE* obj_file;
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)

--- a/test/test_convhull_3d.c
+++ b/test/test_convhull_3d.c
@@ -269,7 +269,7 @@ int main(int argc, const char * argv[])
         path[0] = '\0';
         strcat(path, obj_folder);
         strcat(path, obj_test_files[o]);
-        extractVerticesFromObjFile(path, &vertices, &nVert);
+        extract_vertices_from_obj_file(path, &vertices, &nVert);
         printf("TEST: building convexhull of ");
         printf(path);
 #ifdef TEST_CONVHULL_ND_INSTEAD


### PR DESCRIPTION
I totally understand that this may be a naming inconsistency that you do not wish to address at this point due to inclusion in other places, but it struck me as odd that the extract function is in camel case, whereas the rest of the functions are snake case.

There's also a small layout change (again for consistency) to do with parameters to the extract function).

This PR address that issue in source, test and documentation, should you wish to make things consistent. If not, please close.