### PR TITLE
Memory approach

### DIFF
--- a/convhull_3d.h
+++ b/convhull_3d.h
@@ -242,6 +242,7 @@ void extract_vertices_from_obj_file_alloc(/* input arguments */
 #endif
 #ifndef ch_stateful_resize
     #define ch_stateful_resize(allocator, ptr, size) default_memory_resize(allocator, ptr, size)
+    #define CONVHULL_CREATE_DEFAULT_RESIZE 1
 #endif
 
 #define CH_MAX_NUM_FACES 50000
@@ -255,7 +256,6 @@ typedef struct float_w_idx {
 }float_w_idx;
 
 /* internal functions prototypes: */
-static void* default_memory_resize(void*, void*, size_t);
 static int cmp_asc_float(const void*, const void*);
 static int cmp_desc_float(const void*, const void*);
 static int cmp_asc_int(const void*, const void*);
@@ -267,12 +267,14 @@ static void plane_3d(CH_FLOAT*, CH_FLOAT*, CH_FLOAT*);
 static void ismember(int*, int*, int*, int, int);
 
 /* internal functions definitions: */
+#ifdef CONVHULL_CREATE_DEFAULT_RESIZE
 static void* default_memory_resize(void* allocator, void* ptr, size_t size)
 {
     if (ptr)
         ch_stateful_free(allocator, ptr);
     return ch_stateful_malloc(allocator, size);
 }
+#endif
 
 static int cmp_asc_float(const void *a,const void *b) {
     struct float_w_idx *a1 = (struct float_w_idx*)a;

--- a/convhull_3d.h
+++ b/convhull_3d.h
@@ -665,7 +665,7 @@ void convhull_3d_build_alloc
         /* Get the point that is not on the current face (point p) */
         for(i=0; i<d; i++)
             fVec[i] = faces[k*d+i];
-        sort_int(fVec, d); /* sort accending */
+        sort_int(fVec, d); /* sort ascending */
         p=k;
         for(i=0; i<d; i++)
             for(j=0; j<(d+1); j++)
@@ -1343,7 +1343,7 @@ void convhull_nd_build_alloc
         /* Get the point that is not on the current face (point p) */
         for(i=0; i<d; i++)
             fVec[i] = faces[k*d+i];
-        sort_int(fVec, d); /* sort accending */
+        sort_int(fVec, d); /* sort ascending */
         p=k;
         for(i=0; i<d; i++)
             for(j=0; j<(d+1); j++)

--- a/convhull_3d.h
+++ b/convhull_3d.h
@@ -257,8 +257,8 @@ typedef struct float_w_idx {
 /* internal functions prototypes: */
 static void* default_memory_resize(void*, void*, size_t);
 static int cmp_asc_float(const void*, const void*);
+static int cmp_desc_float(const void*, const void*);
 static int cmp_asc_int(const void*, const void*);
-static int cmp_desc_int(const void*, const void*);
 static void sort_float(CH_FLOAT*, CH_FLOAT*, int*, int, int, void*);
 static void sort_int(int*, int);
 static ch_vec3 cross(ch_vec3*, ch_vec3*);

--- a/convhull_3d.h
+++ b/convhull_3d.h
@@ -650,7 +650,7 @@ void convhull_3d_build_alloc
             cf[i*d+j] = cfi[j];
         df[i] = dfi;
     }
-    CH_FLOAT A[(CONVHULL_3D_MAX_DIMENSIONS + 1)*(CONVHULL_3D_MAX_DIMENSIONS + 1)];
+    CH_FLOAT A[(CONVHULL_3D_MAX_DIMENSIONS+1)*(CONVHULL_3D_MAX_DIMENSIONS+1)];
     int fVec[CONVHULL_3D_MAX_DIMENSIONS+1];
     int face_tmp[2];
     

--- a/convhull_3d.h
+++ b/convhull_3d.h
@@ -415,7 +415,7 @@ static void plane_3d
     }
     norm_c = (CH_FLOAT)0.0;
     for(i=0; i<3; i++)
-        norm_c += (ch_pow(c[i], 2.0));
+        norm_c += (ch_pow(c[i], (CH_FLOAT)2.0));
     norm_c = ch_sqrt(norm_c);
     for(i=0; i<3; i++)
         c[i] /= norm_c;
@@ -475,7 +475,7 @@ static void plane_nd
     }
     norm_c = (CH_FLOAT)0.0;
     for(i=0; i<Nd; i++)
-        norm_c += (pow(c[i], 2.0));
+        norm_c += (ch_pow(c[i], (CH_FLOAT)2.0));
     norm_c = ch_sqrt(norm_c);
     for(i=0; i<Nd; i++)
         c[i] /= norm_c;
@@ -679,7 +679,7 @@ void convhull_3d_build
     desReldist = (CH_FLOAT*)ch_malloc((nVert-d-1) * sizeof(CH_FLOAT));
     for(i=0; i<(nVert-d-1); i++)
         for(j=0; j<d; j++)
-            reldist[i] += ch_pow(absdist[i*d+j], 2.0);
+            reldist[i] += ch_pow(absdist[i*d+j], (CH_FLOAT)2.0);
     
     /* Sort from maximum to minimum relative distance */
     int num_pleft, cnt;
@@ -1346,7 +1346,7 @@ void convhull_nd_build
     desReldist = (CH_FLOAT*)ch_malloc((nVert-d-1) * sizeof(CH_FLOAT));
     for(i=0; i<(nVert-d-1); i++)
         for(j=0; j<d; j++)
-            reldist[i] += ch_pow(absdist[i*d+j], 2.0);
+            reldist[i] += ch_pow(absdist[i*d+j], (CH_FLOAT)2.0);
 
     /* Sort from maximum to minimum relative distance */
     int num_pleft, cnt;
@@ -1744,7 +1744,7 @@ void delaunay_nd_mesh
      * This is the point that can see the entire lower hull. */
     w_optimal = 0.0;
     for(j=0; j<nd; j++)
-       w_optimal += (2.0*pow(p0[j], 2.0));
+       w_optimal += (2.0*ch_pow(p0[j], (CH_FLOAT)2.0));
     w_optimal = w0-w_optimal;
 
     /* Subtract 1000 times the absolute value of w_optimal to ensure that the point where the tangent plane

--- a/convhull_3d.h
+++ b/convhull_3d.h
@@ -749,7 +749,7 @@ void convhull_3d_build_alloc
     int face_s[CONVHULL_3D_MAX_DIMENSIONS];
     int gVec[CONVHULL_3D_MAX_DIMENSIONS];
     int* visible_ind, *visible, *nonvisible_faces, *f0, *u, *horizon, *hVec, *pp, *hVec_mem_face;
-    int num_visible_ind, num_nonvisible_faces, n_newfaces, count, vis;
+    int num_visible_ind, num_nonvisible_faces, n_newfaces, n_realloc_faces, count, vis;
     int f0_sum, u_len, start, num_p, index, horizon_size1;
     int FUCKED;
     FUCKED = 0;
@@ -890,20 +890,21 @@ void convhull_3d_build_alloc
             
             /* Update the number of faces */
             nFaces = nFaces-num_visible_ind;
-            faces = (int*)ch_stateful_realloc(allocator, faces, nFaces*d*sizeof(int));
-            cf = (CH_FLOAT*)ch_stateful_realloc(allocator, cf, nFaces*d*sizeof(CH_FLOAT));
-            df = (CH_FLOAT*)ch_stateful_realloc(allocator, df, nFaces*sizeof(CH_FLOAT));
             
             /* start is the first row of the new faces */
             start=nFaces;
             
             /* Add faces connecting horizon to the new point */
             n_newfaces = horizon_size1;
+            n_realloc_faces = nFaces + n_newfaces;
+            if (n_realloc_faces > CH_MAX_NUM_FACES)
+                n_realloc_faces = CH_MAX_NUM_FACES+1;
+            faces = (int*)ch_stateful_realloc(allocator, faces, n_realloc_faces*d*sizeof(int));
+            cf = (CH_FLOAT*)ch_stateful_realloc(allocator, cf, n_realloc_faces*d*sizeof(CH_FLOAT));
+            df = (CH_FLOAT*)ch_stateful_realloc(allocator, df, n_realloc_faces*sizeof(CH_FLOAT));
+        
             for(j=0; j<n_newfaces; j++){
                 nFaces++;
-                faces = (int*)ch_stateful_realloc(allocator, faces, nFaces*d*sizeof(int));
-                cf = (CH_FLOAT*)ch_stateful_realloc(allocator, cf, nFaces*d*sizeof(CH_FLOAT));
-                df = (CH_FLOAT*)ch_stateful_realloc(allocator, df, nFaces*sizeof(CH_FLOAT));
                 for(k=0; k<d-1; k++)
                     faces[(nFaces-1)*d+k] = horizon[j*(d-1)+k];
                 faces[(nFaces-1)*d+(d-1)] = i;
@@ -1430,7 +1431,7 @@ void convhull_nd_build_alloc
     int face_s[CONVHULL_ND_MAX_DIMENSIONS];
     int gVec[CONVHULL_ND_MAX_DIMENSIONS];
     int* visible_ind, *visible, *nonvisible_faces, *f0, *u, *horizon, *hVec, *pp, *hVec_mem_face;
-    int num_visible_ind, num_nonvisible_faces, n_newfaces, count, vis;
+    int num_visible_ind, num_nonvisible_faces, n_newfaces, n_realloc_faces, count, vis;
     int f0_sum, u_len, start, num_p, index, horizon_size1;
     int FUCKED;
     FUCKED = 0;
@@ -1571,20 +1572,21 @@ void convhull_nd_build_alloc
 
             /* Update the number of faces */
             nFaces = nFaces-num_visible_ind;
-            faces = (int*)ch_stateful_realloc(allocator, faces, nFaces*d*sizeof(int));
-            cf = (CH_FLOAT*)ch_stateful_realloc(allocator, cf, nFaces*d*sizeof(CH_FLOAT));
-            df = (CH_FLOAT*)ch_stateful_realloc(allocator, df, nFaces*sizeof(CH_FLOAT));
 
             /* start is the first row of the new faces */
             start=nFaces;
 
             /* Add faces connecting horizon to the new point */
             n_newfaces = horizon_size1;
+            n_realloc_faces = nFaces + n_newfaces;
+            if (n_realloc_faces > CH_MAX_NUM_FACES)
+                n_realloc_faces = CH_MAX_NUM_FACES+1;
+            faces = (int*)ch_stateful_realloc(allocator, faces, (nFaces+n_newfaces)*d*sizeof(int));
+            cf = (CH_FLOAT*)ch_stateful_realloc(allocator, cf, (nFaces+n_newfaces)*d*sizeof(CH_FLOAT));
+            df = (CH_FLOAT*)ch_stateful_realloc(allocator, df, (nFaces+n_newfaces)*sizeof(CH_FLOAT));
+
             for(j=0; j<n_newfaces; j++){
                 nFaces++;
-                faces = (int*)ch_stateful_realloc(allocator, faces, nFaces*d*sizeof(int));
-                cf = (CH_FLOAT*)ch_stateful_realloc(allocator, cf, nFaces*d*sizeof(CH_FLOAT));
-                df = (CH_FLOAT*)ch_stateful_realloc(allocator, df, nFaces*sizeof(CH_FLOAT));
                 for(k=0; k<d-1; k++)
                     faces[(nFaces-1)*d+k] = horizon[j*(d-1)+k];
                 faces[(nFaces-1)*d+(d-1)] = i;


### PR DESCRIPTION
I know that this is quite a lot, but I have tested that old behaviour is unaffected in terms of:
- numeric output in relation to master
- performance speed
- use of previous allocators / in old code

**The key important aims here are:**
- to reduce calls to allocate
- to allow the use of an allocator with state (such as a real-time allocator)

**The key changes are:**
- stateful allocators using macro defines (so that binding is compile-time and the style is consistent
- use of local arrays for some of the vectors (reducing calls to alloc/free)
- the introduction of a resize concept (like realloc but doesn't copy) for reusing pointers where possible
- reliance on resize/realloc to act as malloc if the pointer Is NULL (as is required for realloc)
- all memory clean-up moves to the end of functions
- sort_int is simplified (it's always ascending and inplace but it was copying which is unnecessary)

Note that in this version all memory calls should now use ch_stateful_ versions to make sure they call through with allocator state if it does exist - for default usage there is no state and the calls map directly to ch_malloc etc.

Thanks for considering - it does alter more of the code than I'd like, but hopefully the changes are understandable.

I think this gets me where I need to be in terms of my usage. It allows me to speed up the process considerably (although for some reason I can't get the same benefits with the standard allocators even if I code the same tricks outside) - I can do a 40 channel speaker array in about 80 microseconds whereas it's about 200 for the default allocators. 

Hopefully the commits are organised well enough that it can be followed through fairly quickly.