### PR TITLE
Correct test for the number of vertices

### DIFF
--- a/convhull_3d.h
+++ b/convhull_3d.h
@@ -591,7 +591,7 @@ void convhull_3d_build_alloc
     CH_FLOAT p_s[CONVHULL_3D_MAX_DIMENSIONS*CONVHULL_3D_MAX_DIMENSIONS];
     CH_FLOAT* points, *cf, *df;
     
-    if(nVert<3 || in_vertices==NULL){
+    if(nVert<=3 || in_vertices==NULL){
         (*out_faces) = NULL;
         (*nOut_faces) = 0;
         return;


### PR DESCRIPTION
The 3D builds requires that there are at least 3 vertices, but it should require 4 or more (the test is correct in the ND version using <= rather than <).

As the function will make a huge allocation if the number of vertices is 3 and crash this PR fixes the test to ensure that 4 or more vertices are required.