### PR TITLE
Addresses assert about Issues building in higher dimensions.

### DIFF
--- a/convhull_3d.h
+++ b/convhull_3d.h
@@ -617,9 +617,12 @@ void convhull_3d_build_alloc
             min_p = MIN(min_p, points[i*(d+1)+j]);
         }
         span[j] = max_p - min_p;
-        /* If you hit this assertion error, then the input vertices do not span all 3 dimensions. Therefore the convex hull cannot be built.
-         * In these cases, reduce the dimensionality of the points and call convhull_nd_build() instead with d<3 */
-        assert(span[j]>0.0000001f);
+#ifndef CONVHULL_ALLOW_BUILD_IN_HIGHER_DIM
+        /* If you hit this assertion error, then the input vertices do not span all 3 dimensions. Therefore the convex hull could be built in less dimensions.
+         * In these cases, consider reducing the dimensionality of the points and calling convhull_nd_build() instead with d<3
+         * You can turn this assert off using CONVHULL_ALLOW_BUILD_IN_HIGHER_DIM if you still wish to build in a higher number of dimensions. */
+        assert(span[j]>0.000000001);
+#endif
     }
     
     /* The initial convex hull is a simplex with (d+1) facets, where d is the number of dimensions */
@@ -1296,9 +1299,12 @@ void convhull_nd_build_alloc
             min_p = MIN(min_p, points[i*(d+1)+j]);
         }
         span[j] = max_p - min_p;
-        /* If you hit this assertion error, then the input vertices do not span all 'd' dimensions. Therefore the convex hull cannot be built.
-         * In these cases, reduce the dimensionality of the points and call convhull_nd_build() instead with d<3 */
+#ifndef CONVHULL_ALLOW_BUILD_IN_HIGHER_DIM
+        /* If you hit this assertion error, then the input vertices do not span all 'd' dimensions. Therefore the convex hull could be built in less dimensions.
+         * In these cases, consider reducing the dimensionality of the points and calling convhull_nd_build() with a smaller d
+         * You can turn this assert off using CONVHULL_ALLOW_BUILD_IN_HIGHER_DIM if you still wish to build in a higher number of dimensions. */
         assert(span[j]>0.000000001);
+#endif
     }
 
     /* The initial convex hull is a simplex with (d+1) facets, where d is the number of dimensions */


### PR DESCRIPTION
There's an assert about creating 1D/2D hulls in 3D and similarly for ND.

I've tried it and it works fine as long as there are enough vertices to start with (I think the use of rnd() means that internally everything ends up ND even if it isn't at input - enough for the algorithm to work). Here I've:

- changed the comments
- allowed the assert to be bypassed with a compiler macro
- Used the same constant for 3D and ND (which would have been enough to skip the assert in my case and probably all others)

I'm not sure what the best thing here more generally is. It looks like the value would be better set according to whether it is single precision or not, but as I'm going to turn it off anyway I just though consistency was the best thing for now.