### PR TITLE
Fix a memory leak when creating a hull from 4 vertices

### DIFF
--- a/convhull_3d.h
+++ b/convhull_3d.h
@@ -730,7 +730,8 @@ void convhull_3d_build_alloc
     int num_pleft, cnt;
     int* ind, *pleft;
     ind = (int*)ch_stateful_malloc(allocator, (nVert-d-1) * sizeof(int));
-    pleft = (int*)ch_stateful_malloc(allocator, (nVert-d-1) * sizeof(int));
+    if ((nVert-d-1)!=0)
+        pleft = (int*)ch_stateful_malloc(allocator, (nVert-d-1) * sizeof(int));
     sort_float(reldist, desReldist, ind, (nVert-d-1), 1, allocator);
     
     /* Initialize the vector of points left. The points with the larger relative


### PR DESCRIPTION
Fixes #20

There was a tiny (0 bytes, but allocating 0 bytes likely still uses memory for bookkeeping) memory leak that was also reported by Valgrind memory analyzer. This only happened when creating a hull from 4 vertices (tetrahedron). The hulls were ok and this fix doesn't affect those.